### PR TITLE
Convert Markdown to WordPress Quasi-Markdown

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -42,13 +42,12 @@ echo "Versions match in readme.txt and PHP file. Let's proceed..."
 cd "$GITPATH"
 echo -e "Enter a commit message for this new version: \c"
 read COMMITMSG
-# git commit -am "$COMMITMSG"
+git commit -am "$COMMITMSG"
 
 echo "Tagging new version in git"
 git tag -a "$NEWVERSION1" -m "Tagging version $NEWVERSION1"
 
 echo "Pushing latest commit to origin, with tags"
-git push origin master
 git push origin master --tags
 
 echo 

--- a/deploy.sh
+++ b/deploy.sh
@@ -26,7 +26,11 @@ echo ".........................................."
 echo 
 
 # Check version in readme.txt is the same as plugin file
-NEWVERSION1=`grep "^Stable tag" "$GITPATH/readme.txt" | awk -F' ' '{print $3}' | sed 's/[[:space:]]//g'`
+if [ -f readme.md ]; then
+	NEWVERSION1=`grep "^Stable tag" "$GITPATH/readme.md" | awk -F' ' '{print $3}' | sed 's/[[:space:]]//g'`
+else
+	NEWVERSION1=`grep "^Stable tag" "$GITPATH/readme.txt" | awk -F' ' '{print $3}' | sed 's/[[:space:]]//g'`
+fi
 echo "readme version: $NEWVERSION1"
 NEWVERSION2=`grep "^Version" "$GITPATH/$MAINFILE" | awk -F' ' '{print $2}' | sed 's/[[:space:]]//g'`
 echo "$MAINFILE version: $NEWVERSION2"
@@ -62,6 +66,13 @@ README.md
 
 echo "Changing directory to SVN and committing to trunk"
 cd $SVNPATH/trunk/
+
+# Transform the readme
+if [ -f readme.md ]; then
+	mv readme.md readme.txt
+	sed -i '' -e 's/^# \(.*\)$/=== \1 ===/' -e 's/^## \(.*\)$/== \1 ==/' -e 's/^### \(.*\)$/= \1 =/' readme.txt
+fi
+
 # Add all new files that are not set to be ignored
 svn status | grep -v "^.[ \t]*\..*" | grep "^?" | awk '{print $2}' | xargs svn add
 svn commit --username=$SVNUSER -m "$COMMITMSG"

--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,16 @@ Edit these lines:
 * Make it executable with `chmod 755 deploy.sh`.
 * Run `./deploy.sh` to deploy master to wordpress.org.
 
+## Readme Markdown
+
+If you choose to use a readme.md file for Github, instead of having two files just use the readme.md with the proper heading usage, the script will automatically convert:
+
+* "# Plugin title" becomes "=== Plugin title ==="
+* "## Section title" becomes "== Section title =="
+* "### Sub heading" becomes "= Sub heading ="
+
+Outside of the different headings, everything else in the file must match the syntax that WordPress expects. The single readme file can work for both places.
+
 # Ignoring Files
 
 If you have files in your Git repository that you would not like to commit to the WordPress repo, find and edit these lines:


### PR DESCRIPTION
I prefer not to have two readme's, and the WordPress readme is markdown with different headings. So I edited this script to look for the readme.md and if it is found to convert to readme.txt and then fix the headings. This keeps a good looking readme file for Github and let's me use that as a base plugin URL for issues and things of that nature. 

Never really made a pull request before so if I did something wrong please forgive me.

Jason
